### PR TITLE
students can add/remove sections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'webpacker', '~> 4.0'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'bootstrap', '~> 5.0'
 gem 'tod'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,9 +61,14 @@ GEM
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
+    autoprefixer-rails (10.4.19.0)
+      execjs (~> 2)
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    bootstrap (5.3.3)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.11.8, < 3)
     builder (3.3.0)
     byebug (11.1.3)
     capybara (3.36.0)
@@ -81,6 +86,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     erubi (1.13.0)
+    execjs (2.10.0)
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -119,6 +125,7 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
+    popper_js (2.11.8)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -228,6 +235,7 @@ PLATFORMS
 DEPENDENCIES
   annotate
   bootsnap (>= 1.4.2)
+  bootstrap (~> 5.0)
   byebug
   capybara
   jbuilder (~> 2.7)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
  *= require_tree .
  *= require_self
  */
+
+ @import "bootstrap";

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,5 +1,5 @@
 class SectionsController < ApplicationController
-  before_action :set_section, only: %i[ show edit update destroy ]
+  before_action :set_section, only: %i[ show edit update destroy enroll withdraw ]
 
   # GET /sections or /sections.json
   def index
@@ -55,6 +55,28 @@ class SectionsController < ApplicationController
       format.html { redirect_to sections_path, status: :see_other, notice: "Section was successfully destroyed." }
       format.json { head :no_content }
     end
+  end
+
+  def enroll
+    student_section = StudentSection.new(student: current_student, section: @section)
+
+    if student_section.save
+      flash[:notice] = "Successfully enrolled in the section."
+      redirect_to student_path(current_student)
+    else
+      flash[:alert] = "Enrollment failed: #{student_section.errors.full_messages.to_sentence}"
+      redirect_to section_path(@section)
+    end
+  end
+
+  def withdraw
+    if current_student.sections.include?(@section)
+      current_student.sections.delete(@section)
+      flash[:notice] = "Successfully withdrew from the section."
+    else
+      flash[:alert] = "You're not enrolled in this section."
+    end
+    redirect_to @section
   end
 
   private

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -27,7 +27,7 @@ class Section < ApplicationRecord
   validate :days_of_week_present
   validate :valid_days_of_week
   validate :validate_start_date
-  # validate :valid_time_range
+  validate :valid_time_range
   validate :time_within_operating_hours
 
   def on_day?(day)

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -19,16 +19,15 @@ class Section < ApplicationRecord
   has_many :student_sections
   has_many :students, through: :student_sections
 
-  # serialize :days_of_week, JSON
+  serialize :days_of_week, JSON
   attribute :end_time, :time_only
   attribute :start_time, :time_only
 
-  # Validations
   validates :teacher_id, :subject_id, :classroom_id, :start_time, :end_time, presence: true
   validate :days_of_week_present
   validate :valid_days_of_week
   validate :validate_start_date
-  validate :valid_time_range
+  # validate :valid_time_range
   validate :time_within_operating_hours
 
   def on_day?(day)

--- a/app/models/student_section.rb
+++ b/app/models/student_section.rb
@@ -22,4 +22,23 @@
 class StudentSection < ApplicationRecord
   belongs_to :student
   belongs_to :section
+
+  validate :no_time_overlap
+
+  private
+
+  def no_time_overlap
+    student.sections.each do |existing_section|
+      next if (existing_section.days_of_week & section.days_of_week).empty?
+
+      new_section_time = Tod::Shift.new(section.start_time, section.end_time)
+      existing_section_time = Tod::Shift.new(existing_section.start_time, existing_section.end_time)
+
+      if new_section_time.overlaps?(existing_section_time)
+        errors.add(:base, "This section conflicts with an existing section in the student's schedule.")
+        break
+      end
+    end
+  end
+
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,3 +4,6 @@
 <%= link_to 'Classrooms', classrooms_path %>
 <%= link_to 'Sections', sections_path %>
 <%= link_to 'Students', students_path %>
+<%- if current_student %>
+  <%= link_to 'My schedule', student_path(current_student) %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,11 @@
 
   <body>
     <%= render partial: 'layouts/header' %>
+    <% flash.each do |type, msg| %>
+      <div class="alert alert-info">
+        <%= msg %>
+      </div>
+    <% end %>
     <br>
     <%= yield %>
   </body>

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -11,7 +11,7 @@
       <th>Start time</th>
       <th>End time</th>
       <th>Days of week</th>
-      <th colspan="3"></th>
+      <th colspan="4"></th>
     </tr>
   </thead>
 
@@ -27,6 +27,13 @@
         <td><%= link_to 'Show', section %></td>
         <td><%= link_to 'Edit', edit_section_path(section) %></td>
         <td><%= link_to 'Destroy', section, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if current_student %>
+          <% if current_student.sections.include?(section) %>
+            <td><%= link_to "Withdraw from Section", withdraw_section_path(section), method: :delete %></td>
+          <% else %>
+            <td><%= link_to "Enroll in Section", enroll_section_path(section), method: :post %></td>
+          <% end %>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -32,3 +32,11 @@
 
 <%= link_to 'Edit', edit_section_path(@section) %> |
 <%= link_to 'Back', sections_path %>
+
+<% if current_student %>
+  <% if current_student.sections.include?(@section) %>
+    <%= button_to "Withdraw from Section", withdraw_section_path(@section), method: :delete %>
+  <% else %>
+    <%= button_to "Enroll in Section", enroll_section_path(@section), method: :post %>
+  <% end %>
+<% end %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -13,7 +13,6 @@
         <td><%= student.full_name %></td>
         <td>
           <%= button_to "Login as #{student.full_name}", login_as_student_path(student), method: :post %>
-          <%= button_to "Show Schedule", student_path(student), method: :get %>
         </td>
       </tr>
     <% end %>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -8,6 +8,7 @@
       <th>Start Time</th>
       <th>End Time</th>
       <th>Days of Week</th>
+      <th colspan="1"></th>
     </tr>
   </thead>
   <tbody>
@@ -18,6 +19,7 @@
         <td><%= section.start_time %></td>
         <td><%= section.end_time %></td>
         <td><%= section.days_of_week.join(", ") %></td>
+        <td><%= link_to "Withdraw from Section", withdraw_section_path(section), method: :delete %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 Rails.application.routes.draw do
   root to: 'subjects#index'
-  
-  resources :sections
+
+  resources :sections  do
+    member do
+      post 'enroll'
+      delete 'withdraw'
+    end
+  end
   resources :classrooms
   resources :teachers do
     resources :teacher_subjects, shallow: true

--- a/test/fixtures/sections.yml
+++ b/test/fixtures/sections.yml
@@ -13,18 +13,16 @@
 #  teacher_id   :integer
 #
 
-# one:
-#   teacher_id: math_teacher
-#   subject_id: math
-#   classroom_id: one
-#   start_time: 2024-10-31 12:00:00
-#   end_time: 2024-10-31 12:50:00
-#   days_of_week: '["Monday", "Tuesday"]'
+one:
+  teacher_id: math_teacher
+  subject_id: math
+  classroom_id: one
+  start_time: 2024-10-31 12:00:00
+  end_time: 2024-10-31 12:50:00
 
-# two:
-#   teacher_id: english_teacher
-#   subject_id: menglish
-#   classroom_id: two
-#   start_time: 2024-10-31 14:00:00
-#   end_time: 2024-10-31 15:20:00
-#   days_of_week: !ruby/array ["Friday"]
+two:
+  teacher_id: english_teacher
+  subject_id: menglish
+  classroom_id: two
+  start_time: 2024-10-31 14:00:00
+  end_time: 2024-10-31 15:20:00

--- a/test/fixtures/student_sections.yml
+++ b/test/fixtures/student_sections.yml
@@ -20,10 +20,10 @@
 #  student_id  (student_id => students.id)
 #
 
-# one:
-#   student: one
-#   section: one
+one:
+  student: one
+  section: one
 
-# two:
-#   student: two
-#   section: two
+two:
+  student: two
+  section: two


### PR DESCRIPTION
Students should be able to add/remove sections to their schedule
A student cannot be in two sections that overlap
For instance, if I add General Chemistry 1 to my schedule, and it's on MWF from 8:00 to 8:50am, I cannot enroll in any other sections between 8:00 and 8:50am on Mondays, Wednesdays, or Fridays.